### PR TITLE
Corrections and improvements

### DIFF
--- a/System76-Software.md
+++ b/System76-Software.md
@@ -7,62 +7,53 @@
 Using the AUR for system76 packages:
 
 ```
-sudo pacman -S base-devel git dfu-programmer efibootmgr rust typescript dmidecode dkms linux-headers at python-cffi python-distro python-evdev python-pynacl python-systemd python-xlib
+sudo pacman -S --needed base-devel git linux-headers
 ```
 
 ---
 **NOTE**
-  For Manjaro make sure to match with the kernel version. Current Manjaro uses the 5.9 kernel so use #8. You can use this command to find the kernel version:
+  For Manjaro make sure to match with the kernel version. Manjaro offers several kernels including the latest stable and LTS versions. You can use this command to find the kernel version:
 
 ```
-uname -a
+uname -r
 ```
 
 For any GNOME Shell extensions to show up in the Extensions application you will need to log out and back in.
 
-## Build and Install system76-firmware-daemon
+## Build and Install system76-firmware
 
-### Download PKGBUILD package and untar it:
+### Download PKGBUILD:
 
 ```
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-firmware-daemon.tar.gz
-tar -xf system76-firmware-daemon.tar.gz
+git clone https://aur.archlinux.org/system76-firmware.git
 ```
 
 ### Run these commands:
 
 ```
 cd system76-firmware-daemon
-makepkg -i
+makepkg -srcif
 ```
  
 ### Now to enable and start the service:
 
 ```
-sudo systemctl enable system76-firmware-daemon
-sudo systemctl start system76-firmware-daemon
+sudo systemctl enable --now system76-firmware-daemon
 ```
 
 ## Build and Install firmware-manager
 
-### Download PKGBUILD package and untar it:
+### Download PKGBUILD:
 
 ```
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/firmware-manager.tar.gz
-tar -xf firmware-manager.tar.gz
+git clone https://aur.archlinux.org/firmware-manager.git
 ```
 
 ### Run these commands:
 
 ```
 cd firmware-manager
-makepkg -i
-```
-
-The Firmware Manager may need to be ran as root or with sudo to work correctly. You can add your user to the adm group to use the tool without sudo:
-
-```
-sudo gpasswd -a $USER adm
+makepkg -srcif
 ```
 
 ---
@@ -71,36 +62,33 @@ These packages need to be installed in this order for them to complete their bui
 
 ## Build and Install system76-dkms
 
-### Download PKGBUILD package and untar it:
+### Download PKGBUILD:
 
 ```
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-dkms.tar.gz
-tar -xf system76-dkms.tar.gz
+git clone https://aur.archlinux.org/system76-dkms.git
 ```
 
 ### Run these commands:
 
 ```
 cd system76-dkms
-makepkg -i
+makepkg -srcif
 ```
 
 ## Build and Install system76-power
 
-### Download PKGBUILD package and untar it:
+### Download PKGBUILD:
 
 ```
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-power.tar.gz
-tar -xf system76-power.tar.gz
+git clone https://aur.archlinux.org/system76-power.git
 ```
 
 ### Run these commands:
 
 ```
 cd system76-power
-makepkg -i
-sudo systemctl enable system76-power
-sudo systenctl start system76-power
+makepkg -srcif
+sudo systemctl enable --now system76-power
 ```
 
 **NOTE**
@@ -112,87 +100,81 @@ sudo systenctl start system76-power
 
 ## Build and Install gnome-shell-extension-system76-power
 
-### Download PKGBUILD package and untar it:
+### Download PKGBUILD:
 
 ```
-wget wget https://aur.archlinux.org/cgit/aur.git/snapshot/gnome-shell-extension-system76-power.tar.gz
-tar -xf gnome-shell-extension-system76-power.tar.gz
+git clone https://aur.archlinux.org/gnome-shell-extension-system76-power-git.git
 ```
 
 ### Run these commands:
 
 ```
 cd gnome-shell-extension-system76-power
-makepkg -i
+makepkg -srcif
 ```
 
 ## Build and Install system76-driver
 
 **NOTE**
-The AUR version is out of date.
+The package is currently is out of date.
 
-### Download PKGBUILD package and untar it:
+### Download PKGBUILD:
 
 ```
-wget wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-driver.tar.gz
-tar -xf system76-driver.tar.gz
+git clone https://aur.archlinux.org/system76-driver.git
 ```
 
 ### Run these command:
 
 ```
 cd system76-driver
-makepkg -i
-sudo systemctl enable system76
-sudo systemctl start system76
+makepkg -srcif
+sudo systemctl enable --now system76
 ```
 
 ## Build and Install system76-io-dkms 
 (this is only needed for the Thelio Io board)
 
-### Download PKGBUILD package and untar it:
+### Download PKGBUILD:
 
 ```
-wget wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-io-dkms.tar.gz
-tar -xf system76-io-dkms.tar.gz
+git clone https://aur.archlinux.org/system76-io-dkms.git
 ```
 
 ### Run these commands:
 
 ```
 cd system76-io-dkms
-makepkg -i
+makepkg -srcif
 ```
 
 ## Build and Install system76-acpi-dkms
 
-### Download PKGBUILD package and untar it:
+### Download PKGBUILD:
 
 ```
-wget wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-acpi-dkms.tar.gz
-tar -xf system76-acpi-dkms
+git clone https://aur.archlinux.org/system76-acpi-dkms.git
 ```
 
 ### Run these commands:
 
 ```
 cd system76-acpi-dkms
-makepkg -i
+makepkg -srcif
 ```
 
 ## Build and Install system76-oled 
 (this is only needed for systems with OLED panels like the addw1/addw2)
 
-### Download PKGBUILD package and untar it:
+### Download PKGBUILD:
 
 ```
-wget wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-oled.tar.gz
-tar -xf system76-oled.tar.gz
+git clone https://aur.archlinux.org/system76-oled.git
 ```
 
 ### Run these commands:
 
 ```
 cd system76-acpi-oled
-makepkg -i
+makepkg -srcif
 ```

--- a/extra-packages.sh
+++ b/extra-packages.sh
@@ -14,22 +14,15 @@ echo ""
 echo "- Installing Noto Font bundles (helpful for Spot[ify] songs with foreign letters)"
 echo ""
 
-sudo pacman -S noto-fonts-cjk noto-fonts-emoji noto-fonts
-
-echo ""
-echo "- Installing build deps for Pika Backup"
-echo ""
-
-sudo pacman -S meson python-llfuse borg
+sudo pacman -S --needed noto-fonts-cjk noto-fonts-emoji noto-fonts
 
 echo ""
 echo "- Downloading Pika Backup from AUR"
 echo ""
 
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/pika-backup.tar.gz
-tar -xf pika-backup.tar.gz
+git clone https://aur.archlinux.org/pika-backup.git
 
 cd pika-backup
-makepkg -ic
+makepkg -srcif
 cd ..
 

--- a/system76-software-install.sh
+++ b/system76-software-install.sh
@@ -15,10 +15,10 @@ echo "| Installing dependencies |"
 echo "---------------------------"
 sleep 2
 
-sudo pacman -S base-devel git dfu-programmer efibootmgr rust typescript dmidecode dkms linux-headers at python-cffi python-distro python-evdev python-pynacl python-systemd python-xlib wget
+sudo pacman -S --needed base-devel git linux-headers
 
 echo "----------------------------"
-echo "| System76 Firmware Daemon |"
+echo "| System76 Firmware |"
 echo "----------------------------"
 sleep 2
 
@@ -26,23 +26,21 @@ echo ""
 echo "- Downloading from the AUR"
 echo ""
 
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-firmware-daemon.tar.gz
-tar -xf system76-firmware-daemon.tar.gz
+git clone https://aur.archlinux.org/system76-firmware.git
 
 echo ""
 echo "- Entering the directory and building"
 echo ""
 
-cd system76-firmware-daemon
-makepkg -ic
+cd system76-firmware
+makepkg -srcif
 cd ..
- 
+
 echo ""
 echo "- Enabling and starting services"
 echo ""
 
-sudo systemctl enable system76-firmware-daemon
-sudo systemctl start system76-firmware-daemon
+sudo systemctl enable --now system76-firmware-daemon
 
 sleep 5
 
@@ -55,22 +53,15 @@ echo ""
 echo "- Downloading from the AUR"
 echo ""
 
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/firmware-manager.tar.gz
-tar -xf firmware-manager.tar.gz
+git clone https://aur.archlinux.org/firmware-manager.git
 
 echo ""
 echo "- Entering the directory and building"
 echo ""
 
 cd firmware-manager
-makepkg -ic
+makepkg -srcif
 cd ..
-
-echo ""
-echo "- Adding user to adm group"
-echo ""
-
-sudo gpasswd -a $USER adm
 
 sleep 5
 
@@ -83,15 +74,14 @@ echo ""
 echo "- Downloading from the AUR"
 echo ""
 
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-dkms.tar.gz
-tar -xf system76-dkms.tar.gz
+git clone https://aur.archlinux.org/system76-dkms.git
 
 echo ""
 echo "- Entering the directory and building"
 echo ""
 
 cd system76-dkms
-makepkg -ic
+makepkg -srcif
 cd ..
 
 sleep 5
@@ -105,23 +95,21 @@ echo ""
 echo "- Downloading from the AUR"
 echo ""
 
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-power.tar.gz
-tar -xf system76-power.tar.gz
+git clone https://aur.archlinux.org/system76-power.git
 
 echo ""
 echo "- Entering the directory and building"
 echo ""
 
 cd system76-power
-makepkg -ic
+makepkg -srcif
 cd ..
 
 echo ""
 echo "- Enabling and starting services"
 echo ""
 
-sudo systemctl enable system76-power
-sudo systemctl start system76-power
+sudo systemctl enable --now system76-power
 
 sleep 5
 
@@ -134,21 +122,20 @@ echo ""
 echo "- Downloading from the AUR"
 echo ""
 
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/gnome-shell-extension-system76-power-git.tar.gz
-tar -xf gnome-shell-extension-system76-power-git.tar.gz
+git clone https://aur.archlinux.org/gnome-shell-extension-system76-power-git.git
 
 echo ""
 echo "- Entering the directory and building"
 echo ""
 
 cd gnome-shell-extension-system76-power-git
-makepkg -ic
+makepkg -srcif
 cd ..
 
 sleep 5
 
 echo "---------------------------"
-echo "| System76 Driver package |"                                      
+echo "| System76 Driver package |"
 echo "---------------------------"
 sleep 2
 
@@ -156,23 +143,21 @@ echo ""
 echo "- Downloading from the AUR"
 echo ""
 
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-driver.tar.gz
-tar -xf system76-driver.tar.gz
+git clone https://aur.archlinux.org/system76-driver.git
 
 echo ""
 echo "- Entering the directory and building"
 echo ""
 
 cd system76-driver
-makepkg -ic
+makepkg -srcif
 cd ..
 
 echo ""
 echo "- Enabling and starting services"
 echo ""
 
-sudo systemctl enable system76
-sudo systemctl start system76
+sudo systemctl enable --now system76
 
 sleep 5
 
@@ -185,15 +170,14 @@ echo ""
 echo "- Downloading from the AUR"
 echo ""
 
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-acpi-dkms.tar.gz
-tar -xf system76-acpi-dkms.tar.gz
+git clone https://aur.archlinux.org/system76-acpi-dkms.git
 
 echo ""
 echo "- Entering the directory and building"
 echo ""
 
 cd system76-acpi-dkms
-makepkg -ic
+makepkg -srcif
 cd ..
 
 sleep 5
@@ -207,10 +191,9 @@ echo "----------------------------"
 echo -n ": "; read thelio
 case "$thelio" in
 
-Yes) wget wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-io-dkms.tar.gz
-   tar -xf system76-io-dkms.tar.gz
+Yes) git clone https://aur.archlinux.org/system76-io-dkms.git
    cd system76-io-dkms
-   makepkg -ic
+   makepkg -srcif
    cd ..
    ;;
 No) break
@@ -226,10 +209,9 @@ echo "---------------------------------------------"
 echo -n ": "; read addw
 case "$addw" in
 
-Yes) wget wget https://aur.archlinux.org/cgit/aur.git/snapshot/system76-oled.tar.gz
-   tar -xf system76-oled.tar.gz
+Yes) git clone https://aur.archlinux.org/system76-oled.git
    cd system76-oled
-   makepkg -ic
+   makepkg -srcif
    cd ..
    ;;
 No) exit 1
@@ -239,7 +221,7 @@ esac
 # Clean up
 # ---
 
- sudo rm -r system76-firmware-daemon*
+ sudo rm -r system76-firmware*
  sudo rm -r firmware-manager*
  sudo rm -r system76-dkms*
  sudo rm -r system76-power*


### PR DESCRIPTION
- `git` should be used, not `wget` and `tar`. See [Arch User Repository: Acquire build files](https://wiki.archlinux.org/index.php/Arch_User_Repository#Acquire_build_files)
- Use the `-s, --sync` `makepkg` flag to install dependencies instead of manually explicitly installing them. See [`makepkg`](https://archlinux.org/pacman/makepkg.8.html)
- I've added a Polkit policy to `firmware-manager` / `firmware-manager-git`, no need to do anything special to run it anymore.